### PR TITLE
Add check for credentials in streaming API.

### DIFF
--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -88,6 +88,10 @@ type Conn struct {
 // data for the given market pair.
 // The connection will automatically reconnect on error.
 func Dial(keyID, keySecret, pair string) (*Conn, error) {
+	if keyID == "" || keySecret == "" {
+		return nil, errors.New("streaming API requires credentials")
+	}
+
 	c := &Conn{
 		keyID:     keyID,
 		keySecret: keySecret,


### PR DESCRIPTION
When attempting to use the streaming client without an API key, one gets the following cryptic error message:

`invalid character 'E' looking for beginning of value`

This is due to the client attempting to parse the resulting error message as JSON.