### PR TITLE
Fix ErrInvalidOrderType when creating quotes

### DIFF
--- a/bitx.go
+++ b/bitx.go
@@ -566,7 +566,7 @@ func (c *Client) CreateQuote(quoteType, baseAmount, pair string) (QuoteResponse,
 		return QuoteResponse{}, errors.New("quoteType must be either 'BUY' or 'SELL'")
 	}
 	var qr QuoteResponse
-	urlValues := url.Values{"quote_type": {quoteType}, "base_amount": {baseAmount}, "pair": {pair}}
+	urlValues := url.Values{"type": {quoteType}, "base_amount": {baseAmount}, "pair": {pair}}
 	err := c.call("POST", "/api/1/quotes", urlValues, &qr)
 	if err != nil {
 		return QuoteResponse{}, err


### PR DESCRIPTION
Hi,

as mentioned in this [issue](https://github.com/bitx/bitx-go/issues/6), the following code is returning a `bitx: remote error ErrInvalidOrderType Invalid order type` error:

```
client := bitx.NewClient("key", "secret")
quote, err := client.CreateQuote("SELL", "0.01", "ETHEUR")
if err != nil {
  log.Print(err)
}
```

I think the reason is that the parameter `quote_type` should be changed to `type` on [bitx.go#L570](https://github.com/bitx/bitx-go/blob/master/bitx.go#L570) as described in the [API documentation](https://www.luno.com/en/api#quotes-create).