### PR TITLE
Add support for HTTP PUT and DELETE

### DIFF
--- a/bitx.go
+++ b/bitx.go
@@ -41,7 +41,7 @@ func (c *Client) call(method, path string, params url.Values,
 	u.Path = path
 
 	var body *bytes.Reader
-	if method == "GET" {
+	if method == "GET" || method == "PUT" || method == "DELETE" {
 		u.RawQuery = params.Encode()
 		body = bytes.NewReader(nil)
 	} else if method == "POST" {

--- a/bitx.go
+++ b/bitx.go
@@ -41,11 +41,13 @@ func (c *Client) call(method, path string, params url.Values,
 	u.Path = path
 
 	var body *bytes.Reader
-	if method == "GET" || method == "PUT" || method == "DELETE" {
+	if method == "GET" {
 		u.RawQuery = params.Encode()
 		body = bytes.NewReader(nil)
-	} else if method == "POST" {
+	} else if method == "POST" || method == "PUT" || method == "PATCH" {
 		body = bytes.NewReader([]byte(params.Encode()))
+	} else if method == "DELETE" {
+		body = bytes.NewReader(nil)
 	} else {
 		return errors.New("Unsupported method")
 	}


### PR DESCRIPTION
Hi,

as mentioned in this [issue](https://github.com/bitx/bitx-go/issues/10), the following code is returning a `Unsupported Method` error:
```
client := bitx.NewClient("key", "secret")
quote, _ := client.CreateQuote("SELL", "0.01", "ETHEUR")
quote, err := client.DeleteQuote(strconv.FormatInt(quote.ID, 10))
if err != nil {
  log.Println(err)
}
```
I think the reason is that the HTTP request method `DELETE` as well as `PUT` is not supported on [bitx.go#L44](https://github.com/bitx/bitx-go/blob/master/bitx.go#L44) but described in the [API documentation](https://www.luno.com/en/api#quotes-discard). This PR will add support for both methods.
