### PR TITLE
Remove whitespace in QuoteResponse json tag string

### DIFF
--- a/bitx.go
+++ b/bitx.go
@@ -548,11 +548,11 @@ func (c *Client) GetFeeInfo(pair string) (FeeInfo, error) {
 
 // QuoteResponse contains information about a specific quote
 type QuoteResponse struct {
-	ID            int64   `json:"id, string"`
+	ID            int64   `json:"id,string"`
 	Type          string  `json:"type"`
 	Pair          string  `json:"pair"`
-	BaseAmount    float64 `json:"base_amount, string"`
-	CounterAmount float64 `json:"counter_amount, string"`
+	BaseAmount    float64 `json:"base_amount,string"`
+	CounterAmount float64 `json:"counter_amount,string"`
 	CreatedAt     int64   `json:"created_at"`
 	ExpiresAt     int64   `json:"expires_at"`
 	Discarded     bool    `json:"discarded"`


### PR DESCRIPTION
Hi,

there are whitespaces in the json tags of the `QuoteResponse` struct such that unmarshalling into the specified types is not possible. The docs https://golang.org/pkg/reflect/#StructTag say:

> By convention, tag strings are a concatenation of optionally space-separated key:"value" pairs. Each key is a non-empty string consisting of non-control characters other than space (U+0020 ' '), quote (U+0022 '"'), and colon (U+003A ':'). Each value is quoted using U+0022 '"' characters and Go string literal syntax.

This PR removes the whitespaces from the json tags.